### PR TITLE
Update icon paths

### DIFF
--- a/artshow/static/artshow/manage_styles.css
+++ b/artshow/static/artshow/manage_styles.css
@@ -197,15 +197,15 @@ ul.messagelist li {
     margin: 0 0 3px 0;
     border-bottom: 1px solid #ddd;
     color: #666;
-    background: #ffc url(/static/admin/img/icon_success.gif) 5px .3em no-repeat;
+    background: #ffc url(/static/admin/img/icon-yes.svg) 5px .3em no-repeat;
 }
 
 ul.messagelist li.warning{
-    background-image: url(/static/admin/img/icon_alert.gif);
+    background-image: url(/static/admin/img/icon-alert.svg);
 }
 
 ul.messagelist li.error{
-    background-image: url(/static/admin/img/icon_error.gif);
+    background-image: url(/static/admin/img/icon-no.svg);
 }
 .helptext {
 	font-size: x-small;


### PR DESCRIPTION
Icons from the Django admin site are used and have been moved in recent
versions to SVG instead of GIF.