### PR TITLE
Fix piece sticker count on the 1st page

### DIFF
--- a/artshow/templates/artshow/piece_stickers.html
+++ b/artshow/templates/artshow/piece_stickers.html
@@ -66,9 +66,9 @@ body {
 
 </style>
 <body>
-<div class="container">
+<div>
 {% for piece in pieces %}
-{% if forloop.counter|divisibleby:"60" %}</div><div class="container">{% endif %}
+{% if forloop.counter0|divisibleby:"60" %}</div><div class="container">{% endif %}
   <div class="sticker">
     <div class="artist">{{ piece.artist.artistname }}</div>
     <div class="name">{{ piece.name }}</div>


### PR DESCRIPTION
Counter should start from 0 to get 60 stickers on the first page.