### PR TITLE
Enable Amazon SQS support in Celery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /code
 
 # Install native dependencies.
 RUN pip install --upgrade pip pipenv \
- && apk add --no-cache jpeg libpq nginx zlib \
- && apk add --no-cache --virtual .build-deps build-base jpeg-dev postgresql-dev python-dev zlib-dev
+ && apk add --no-cache jpeg libcurl libpq nginx zlib \
+ && apk add --no-cache --virtual .build-deps build-base curl-dev jpeg-dev postgresql-dev python-dev zlib-dev
 
 COPY Pipfile Pipfile.lock /code/
 RUN pipenv install --system

--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ requests = "*"
 psycopg2 = "*"
 supervisor = "*"
 environs = {extras = ["django"],version = "*"}
+celery = {extras = ["sqs"],version = "*"}
 
 [dev-packages]
 "flake8" = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2653033bfab46048ef25becfe988d170e3814e5e7dedbb7283a3406899ea2e21"
+            "sha256": "fbad022e78a7444677f0917e4db92121de9b47233dc9ac6c01e2fc914c3b40f1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -44,12 +44,30 @@
             ],
             "version": "==2.49.0"
         },
-        "celery": {
+        "boto3": {
             "hashes": [
-                "sha256:7c544f37a84a5eadc44cab1aa8c9580dff94636bb81978cdf9bf8012d9ea7d8f",
-                "sha256:d3363bb5df72d74420986a435449f3c3979285941dff57d5d97ecba352a0e3e2"
+                "sha256:a01e3a373638850822c863914fa56e25fd1a651a48fb9c6323694a634c76289c",
+                "sha256:ba1229df5f1e32dee4c8bb73e774dfb7d54e293f0895d4f825294e2d46e3c7b3"
             ],
-            "version": "==4.4.0"
+            "version": "==1.12.16"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:1109f36e658de2097d1e466842d6634a6b66bb9d3779abe16698171360e1ae5f",
+                "sha256:39e903e1d1ae862e469b4d5f15dc6770a7c9c81da9fcffb1a40f551ea36acd35"
+            ],
+            "version": "==1.15.16"
+        },
+        "celery": {
+            "extras": [
+                "sqs"
+            ],
+            "hashes": [
+                "sha256:3c5fcd6bfcf9a6323cb742cfc121d1790d50cfeddf300ba723cfa0b356413f07",
+                "sha256:a650525303ee866fb0c62c82f68681fcc2183eebbfafae552c27d30125fe518b"
+            ],
+            "index": "pypi",
+            "version": "==4.4.1"
         },
         "certifi": {
             "hashes": [
@@ -81,11 +99,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:2f1ba1db8648484dd5c238fb62504777b7ad090c81c5f1fd8d5eb5ec21b5f283",
-                "sha256:c91c91a7ad6ef67a874a4f76f58ba534f9208412692a840e1d125eb5c279cb0a"
+                "sha256:50b781f6cbeb98f673aa76ed8e572a019a45e52bdd4ad09001072dfd91ab07c8",
+                "sha256:89e451bfbb815280b137e33e454ddd56481fdaa6334054e6e031041ee1eda360"
             ],
             "index": "pypi",
-            "version": "==3.0.3"
+            "version": "==3.0.4"
         },
         "django-ajax-selects": {
             "hashes": [
@@ -155,6 +173,14 @@
             ],
             "version": "==0.6.2"
         },
+        "docutils": {
+            "hashes": [
+                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
+                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
+                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
+            ],
+            "version": "==0.15.2"
+        },
         "environs": {
             "extras": [
                 "django"
@@ -187,19 +213,26 @@
             ],
             "version": "==2.9"
         },
+        "jmespath": {
+            "hashes": [
+                "sha256:695cb76fa78a10663425d5b73ddc5714eb711157e52704d69be03b1a02ba4fec",
+                "sha256:cca55c8d153173e21baa59983015ad0daf603f9cb799904ff057bfb8ff8dc2d9"
+            ],
+            "version": "==0.9.5"
+        },
         "kombu": {
             "hashes": [
-                "sha256:2a9e7adff14d046c9996752b2c48b6d9185d0b992106d5160e1a179907a5d4ac",
-                "sha256:67b32ccb6fea030f8799f8fd50dd08e03a4b99464ebc4952d71d8747b1a52ad1"
+                "sha256:2d1cda774126a044d91a7ff5fa6d09edf99f46924ab332a810760fe6740e9b76",
+                "sha256:598e7e749d6ab54f646b74b2d2df67755dee13894f73ab02a2a9feb8870c7cb2"
             ],
-            "version": "==4.6.7"
+            "version": "==4.6.8"
         },
         "marshmallow": {
             "hashes": [
-                "sha256:3a94945a7461f2ab4df9576e51c97d66bee2c86155d3d3933fab752b31effab8",
-                "sha256:4b95c7735f93eb781dfdc4dded028108998cad759dda8dd9d4b5b4ac574cbf13"
+                "sha256:90854221bbb1498d003a0c3cc9d8390259137551917961c8b5258c64026b2f85",
+                "sha256:ac2e13b30165501b7d41fc0371b8df35944f5849769d136f20e2c5f6cdc6e665"
             ],
-            "version": "==3.5.0"
+            "version": "==3.5.1"
         },
         "num2words": {
             "hashes": [
@@ -272,6 +305,18 @@
             "index": "pypi",
             "version": "==2.8.4"
         },
+        "pycurl": {
+            "hashes": [
+                "sha256:0f0cdfc7a92d4f2a5c44226162434e34f7d6967d3af416a6f1448649c09a25a4",
+                "sha256:10510a0016c862af467c6e069e051409f15f5831552bed03f5104b395a5d7dd1",
+                "sha256:208dd2c89e80d32a69397ba8a5cdb3bc0dc60f961a4f2a9662e5e1624dc799d1",
+                "sha256:6dc6ee5e7628400083471cba8044010860fe8b22e4dee05e42150a68047d7d9d",
+                "sha256:794bda39ea6fe434b6e1f58ab3bea9f0e6123fb43702fecd760eed6f1547b20a",
+                "sha256:dae7277e7c06da00947f3cd32c095b1e65eae09f07478ada4ea9dfa57020b646",
+                "sha256:eccea049aef47decc380746b3ff242d95636d578c907d0eab3b00918292d6c48"
+            ],
+            "version": "==7.43.0.2"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
@@ -335,6 +380,13 @@
             "index": "pypi",
             "version": "==2.23.0"
         },
+        "s3transfer": {
+            "hashes": [
+                "sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13",
+                "sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db"
+            ],
+            "version": "==0.3.3"
+        },
         "six": {
             "hashes": [
                 "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
@@ -369,6 +421,7 @@
                 "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
                 "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
+            "markers": "python_version != '3.4'",
             "version": "==1.25.8"
         },
         "vine": {

--- a/artshowjockey/settings.py
+++ b/artshowjockey/settings.py
@@ -48,7 +48,8 @@ DEFAULT_FROM_EMAIL = SERVER_EMAIL
 CELERY_BROKER_URL = env.str('BROKER_URL', default='amqp://')
 CELERY_RESULT_BACKEND = 'django-db'
 CELERY_BROKER_TRANSPORT_OPTIONS = {
-    'queue_name_prefix': env.str('CELERY_QUEUE_PREFIX', default='artshowjockey-'),
+    'queue_name_prefix':
+        env.str('CELERY_QUEUE_PREFIX', default='artshowjockey-'),
 }
 
 # Configure mail sent with the backend above to go through the Celery task

--- a/artshowjockey/settings.py
+++ b/artshowjockey/settings.py
@@ -46,20 +46,11 @@ except EnvError:
 SERVER_EMAIL = 'artshow-jockey@furtherconfusion.org'
 DEFAULT_FROM_EMAIL = SERVER_EMAIL
 
+CELERY_BROKER_URL = env.str('BROKER_URL', default='amqp://')
 CELERY_RESULT_BACKEND = 'django-db'
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     'queue_name_prefix': env.str('CELERY_QUEUE_PREFIX', default='artshow-'),
 }
-
-try:
-    from kombu.utils.url import safequote
-
-    aws_access_key = safequote(env.str('AWS_ACCESS_KEY_ID'))
-    aws_secret_key = safequote(env.str('AWS_SECRET_ACCESS_KEY'))
-
-    CELERY_BROKER_URL = f'sqs://{aws_access_key}:{aws_secret_key}@'
-except EnvError:
-    CELERY_BROKER_URL = env.str('BROKER_URL', default='amqp://')
 
 # Configure mail sent with the backend above to go through the Celery task
 # queue.

--- a/artshowjockey/settings.py
+++ b/artshowjockey/settings.py
@@ -29,13 +29,12 @@ try:
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 except EnvError:
     try:
-        with env.prefixed('AWS_'):
+        with env.prefixed('AWS_SES_'):
             AWS_ACCESS_KEY_ID = env('ACCESS_KEY_ID')
             AWS_SECRET_ACCESS_KEY = env('SECRET_ACCESS_KEY')
-            with env.prefixed('SES_'):
-                AWS_SES_REGION_NAME = env('REGION_NAME')
-                AWS_SES_REGION_ENDPOINT = env('REGION_ENDPOINT')
-                AWS_SES_CONFIGURATION_SET = env('CONFIGURATION_SET')
+            AWS_SES_REGION_NAME = env('REGION_NAME')
+            AWS_SES_REGION_ENDPOINT = env('REGION_ENDPOINT')
+            AWS_SES_CONFIGURATION_SET = env('CONFIGURATION_SET')
         EMAIL_BACKEND = 'django_ses.SESBackend'
     except EnvError:
         if DEBUG:

--- a/artshowjockey/settings.py
+++ b/artshowjockey/settings.py
@@ -47,7 +47,19 @@ SERVER_EMAIL = 'artshow-jockey@furtherconfusion.org'
 DEFAULT_FROM_EMAIL = SERVER_EMAIL
 
 CELERY_RESULT_BACKEND = 'django-db'
-CELERY_BROKER_URL = env.str('BROKER_URL', default='amqp://')
+CELERY_BROKER_TRANSPORT_OPTIONS = {
+    'queue_name_prefix': env.str('CELERY_QUEUE_PREFIX', default='artshow-'),
+}
+
+try:
+    from kombu.utils.url import safequote
+
+    aws_access_key = safequote(env.str('AWS_ACCESS_KEY_ID'))
+    aws_secret_key = safequote(env.str('AWS_SECRET_ACCESS_KEY'))
+
+    CELERY_BROKER_URL = f'sqs://{aws_access_key}:{aws_secret_key}@'
+except EnvError:
+    CELERY_BROKER_URL = env.str('BROKER_URL', default='amqp://')
 
 # Configure mail sent with the backend above to go through the Celery task
 # queue.

--- a/artshowjockey/settings.py
+++ b/artshowjockey/settings.py
@@ -30,8 +30,8 @@ try:
 except EnvError:
     try:
         with env.prefixed('AWS_SES_'):
-            AWS_ACCESS_KEY_ID = env('ACCESS_KEY_ID')
-            AWS_SECRET_ACCESS_KEY = env('SECRET_ACCESS_KEY')
+            AWS_SES_ACCESS_KEY_ID = env('ACCESS_KEY_ID')
+            AWS_SES_SECRET_ACCESS_KEY = env('SECRET_ACCESS_KEY')
             AWS_SES_REGION_NAME = env('REGION_NAME')
             AWS_SES_REGION_ENDPOINT = env('REGION_ENDPOINT')
             AWS_SES_CONFIGURATION_SET = env('CONFIGURATION_SET')
@@ -48,7 +48,7 @@ DEFAULT_FROM_EMAIL = SERVER_EMAIL
 CELERY_BROKER_URL = env.str('BROKER_URL', default='amqp://')
 CELERY_RESULT_BACKEND = 'django-db'
 CELERY_BROKER_TRANSPORT_OPTIONS = {
-    'queue_name_prefix': env.str('CELERY_QUEUE_PREFIX', default='artshow-'),
+    'queue_name_prefix': env.str('CELERY_QUEUE_PREFIX', default='artshowjockey-'),
 }
 
 # Configure mail sent with the backend above to go through the Celery task


### PR DESCRIPTION
This change enables Amazon SQS support in Celery. To avoid conflict with django-ses the AWS access key environment variables and settings are now prefixed with "AWS_SES_".