### PR TITLE
Partially optimize cheque creation

### DIFF
--- a/artshow/admin.py
+++ b/artshow/admin.py
@@ -250,8 +250,7 @@ class ArtistAdmin(AjaxSelectAdmin):
         Artist.apply_winnings_and_commission(artists)
 
     def create_cheques(self, request, artists):
-        for a in artists:
-            a.create_cheque()
+        Artist.create_cheques(artists)
 
     # noinspection PyUnusedLocal
     def allocate_spaces(self, request, artists):

--- a/artshow/tests/test_artist.py
+++ b/artshow/tests/test_artist.py
@@ -1,19 +1,13 @@
 from decimal import Decimal
 
-from django.contrib.admin.sites import AdminSite
 from django.conf import settings
 from django.contrib.auth.models import Permission, User
 from django.test import Client, TestCase
 from django.urls import reverse
 
-from ..admin import ArtistAdmin
 from ..models import (
     Allocation, Artist, Bid, Bidder, BidderId, Payment, Piece, Space)
 from peeps.models import Person
-
-
-class MockRequest:
-    pass
 
 
 class ArtistTest(TestCase):
@@ -141,13 +135,9 @@ class ArtistTest(TestCase):
         self.assertEqual(commission.description, '10.0% of sales')
 
     def test_create_cheques(self):
-        site = AdminSite()
-        admin = ArtistAdmin(Artist, site)
-        request = MockRequest()
-
         # Don't apply space fees so that the payment is positive.
         Artist.apply_winnings_and_commission(Artist.objects.all())
-        admin.create_cheques(request, Artist.objects.all())
+        Artist.create_cheques(Artist.objects.all())
 
         self.assertEqual(Payment.objects.count(), 6)
 

--- a/artshow/workflows.py
+++ b/artshow/workflows.py
@@ -417,7 +417,7 @@ def close_show(request):
             artist_queryset = Artist.objects.filter(pk=artist.pk)
             Artist.apply_space_fees(artist_queryset)
             Artist.apply_winnings_and_commission(artist_queryset)
-            artist.create_cheque()
+            Artist.create_cheques(artist_queryset)
             artists_processed += 1
         else:
             artists_remaining += 1


### PR DESCRIPTION
Batch calculation of an artist's outstanding balance is possible but
Django does not allow bulk creation of models like ChequePayment which
use multi-table inheritance.