### PR TITLE
Remove duplicate logger configuration

### DIFF
--- a/artshowjockey/settings.py
+++ b/artshowjockey/settings.py
@@ -204,30 +204,15 @@ if TEST_OAUTH_PROVIDER:
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse'
-        },
-    },
     'handlers': {
         'console': {
             'class': 'logging.StreamHandler',
-        },
-        'mail_admins': {
-            'level': 'ERROR',
-            'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler'
         },
     },
     'loggers': {
         'artshow.square': {
             'handlers': ['console'],
             'level': 'DEBUG',
-            'propagate': True,
-        },
-        'django.request': {
-            'handlers': ['mail_admins'],
-            'level': 'ERROR',
             'propagate': True,
         },
         'paypal': {


### PR DESCRIPTION
Django already sends ERROR logs to AdminEmailHandler. Specifying it here with `propagate: True` means duplicate messages were being sent.