### PR TITLE
Handle OAuth logins with duplicate Person objects

### DIFF
--- a/tinyreg/tests/test_oauth.py
+++ b/tinyreg/tests/test_oauth.py
@@ -5,6 +5,8 @@ from django.contrib.auth.models import User
 from django.test import LiveServerTestCase
 from django.urls import reverse
 
+from peeps.models import Person
+
 from .views import CurrentUserView
 
 # Uncomment for detailed oauthlib logs
@@ -85,4 +87,155 @@ class OAuthTests(LiveServerTestCase):
         self.assertEquals(person.postcode, '12345')
         self.assertEquals(person.country, 'US')
         self.assertEquals(person.phone, '')
+        self.assertEquals(person.email, 'fox@example.com')
+
+    def test_log_in_with_existing_person(self):
+        CurrentUserView.current_user = {
+            'id': 42,
+            'firstName': 'Ignored',
+            'lastName': 'Ignored',
+            'preferredName': 'Ignored',
+            'addressLine1': 'Ignored',
+            'addressLine2': 'Ignored',
+            'addressCity': 'Ignored',
+            'addressState': 'Ignored',
+            'addressZipcode': 'Ignored',
+            'addressCountry': 'Ignored',
+            'phone': 'Ignored',
+            'email': 'Ignored',
+        }
+
+        person = Person(
+            name='Foxy McFoxerson',
+            address1='123 Main St.',
+            address2='Apt 3',
+            city='New York',
+            state='NY',
+            postcode='12345',
+            country='US',
+            phone='800-555-1234',
+            email='fox@example.com',
+            reg_id='42',
+            preferred_name='Mr. Fox')
+        person.save()
+
+        url = reverse('oauth-redirect')
+        response = requests.get(self.live_server_url + url)
+        self.assertEqual(response.status_code, 200)
+
+        user = User.objects.get(username="42")
+        self.assertEquals(user.person.pk, person.pk)
+        self.assertEquals(user.person.reg_id, "42")
+        self.assertEquals(user.person.name, 'Foxy McFoxerson')
+        self.assertEquals(user.person.preferred_name, 'Mr. Fox')
+        self.assertEquals(user.person.address1, '123 Main St.')
+        self.assertEquals(user.person.address2, 'Apt 3')
+        self.assertEquals(user.person.city, 'New York')
+        self.assertEquals(user.person.state, 'NY')
+        self.assertEquals(user.person.postcode, '12345')
+        self.assertEquals(user.person.country, 'US')
+        self.assertEquals(user.person.phone, '800-555-1234')
+        self.assertEquals(user.person.email, 'fox@example.com')
+
+    def test_log_in_with_existing_user_and_duplicate_person(self):
+        CurrentUserView.current_user = {
+            'id': 42,
+            'firstName': 'Ignored',
+            'lastName': 'Ignored',
+            'preferredName': 'Ignored',
+            'addressLine1': 'Ignored',
+            'addressLine2': 'Ignored',
+            'addressCity': 'Ignored',
+            'addressState': 'Ignored',
+            'addressZipcode': 'Ignored',
+            'addressCountry': 'Ignored',
+            'phone': 'Ignored',
+            'email': 'Ignored',
+        }
+
+        user = User(username='42')
+        user.save()
+
+        person = Person(
+            name='Foxy McFoxerson',
+            address1='123 Main St.',
+            address2='Apt 3',
+            city='New York',
+            state='NY',
+            postcode='12345',
+            country='US',
+            phone='800-555-1234',
+            email='fox@example.com',
+            reg_id='42',
+            preferred_name='Mr. Fox',
+            user=user)
+        person.save()
+
+        duplicate_person = Person(
+            name='Foxy McFoxerson',
+            address1='123 Main Street',
+            address2='Apartment 3',
+            city='New York',
+            state='NY',
+            postcode='12345',
+            country='USA',
+            phone='800-555-1234',
+            email='fox@example.com',
+            reg_id='42',
+            preferred_name='')
+        duplicate_person.save()
+
+        url = reverse('oauth-redirect')
+        response = requests.get(self.live_server_url + url)
+        self.assertEqual(response.status_code, 200)
+
+        user = User.objects.get(username="42")
+        self.assertEquals(user.person.pk, person.pk)
+        self.assertEquals(user.person.reg_id, "42")
+        self.assertEquals(user.person.name, 'Foxy McFoxerson')
+        self.assertEquals(user.person.preferred_name, 'Mr. Fox')
+        self.assertEquals(user.person.address1, '123 Main St.')
+        self.assertEquals(user.person.address2, 'Apt 3')
+        self.assertEquals(user.person.city, 'New York')
+        self.assertEquals(user.person.state, 'NY')
+        self.assertEquals(user.person.postcode, '12345')
+        self.assertEquals(user.person.country, 'US')
+        self.assertEquals(user.person.phone, '800-555-1234')
+        self.assertEquals(user.person.email, 'fox@example.com')
+
+    def test_log_in_with_existing_user_without_person(self):
+        CurrentUserView.current_user = {
+            'id': 42,
+            'firstName': 'Foxy',
+            'lastName': 'McFoxerson',
+            'preferredName': 'Mr. Fox',
+            'addressLine1': '123 Main St.',
+            'addressLine2': 'Apt 3',
+            'addressCity': 'New York',
+            'addressState': 'NY',
+            'addressZipcode': '12345',
+            'addressCountry': 'US',
+            'phone': '800-555-1234',
+            'email': 'fox@example.com',
+        }
+
+        user = User(username='42')
+        user.save()
+
+        url = reverse('oauth-redirect')
+        response = requests.get(self.live_server_url + url)
+        self.assertEqual(response.status_code, 200)
+
+        user = User.objects.get(username="42")
+        person = user.person
+        self.assertEquals(person.reg_id, "42")
+        self.assertEquals(person.name, 'Foxy McFoxerson')
+        self.assertEquals(person.preferred_name, 'Mr. Fox')
+        self.assertEquals(person.address1, '123 Main St.')
+        self.assertEquals(person.address2, 'Apt 3')
+        self.assertEquals(person.city, 'New York')
+        self.assertEquals(person.state, 'NY')
+        self.assertEquals(person.postcode, '12345')
+        self.assertEquals(person.country, 'US')
+        self.assertEquals(person.phone, '800-555-1234')
         self.assertEquals(person.email, 'fox@example.com')

--- a/tinyreg/views.py
+++ b/tinyreg/views.py
@@ -40,9 +40,21 @@ def oauth_complete(request):
         include_client_id=True)
 
     user_info = oauth.get(settings.CONCAT_API + '/users/current').json()
+    reg_id = str(user_info['id'])
 
     try:
-        person = Person.objects.get(reg_id=str(user_info['id']))
+        user = User.objects.get(username=reg_id)
+    except User.DoesNotExist:
+        user = User(username=reg_id)
+        user.save()
+
+    try:
+        try:
+            person = user.person
+        except Person.DoesNotExist:
+            person = Person.objects.filter(reg_id=reg_id)[:1].get()
+            person.user = user
+            person.save()
     except Person.DoesNotExist:
         person = Person(
             name=user_info['firstName'] + ' ' + user_info['lastName'],
@@ -54,17 +66,10 @@ def oauth_complete(request):
             country=user_info['addressCountry'],
             phone=user_info.get('phone', ''),
             email=user_info['email'],
-            reg_id=user_info['id'],
-            preferred_name=user_info.get('preferredName', ''))
-
-    try:
-        user = User.objects.get(username=person.reg_id)
-    except User.DoesNotExist:
-        user = User(username=person.reg_id)
-        user.save()
-
-    person.user = user
-    person.save()
+            reg_id=reg_id,
+            preferred_name=user_info.get('preferredName', ''),
+            user=user)
+        person.save()
 
     auth.login(request, user)
     return HttpResponseRedirect(request.session.get('oauth_next', '/'))


### PR DESCRIPTION
This can happen if an attendee registers as both an artist and a bidder, as the bidder registration flow currently always creates a new Person object rather than looking for an existing one based on the provided registration ID.