### PR TITLE
Rework placement of auto buy wording

### DIFF
--- a/artshow/bid_entry.py
+++ b/artshow/bid_entry.py
@@ -60,6 +60,7 @@ def get_bids(piece):
         'last_updated': bids_updated,
         'location': piece.location,
         'locations': piece.artist.assigned_locations(),
+        'buy_now': piece.buy_now,
     })
 
 

--- a/artshow/bid_entry.py
+++ b/artshow/bid_entry.py
@@ -60,7 +60,7 @@ def get_bids(piece):
         'last_updated': bids_updated,
         'location': piece.location,
         'locations': piece.artist.assigned_locations(),
-        'buy_now': piece.buy_now,
+        'buy_now': float(piece.buy_now),
     })
 
 

--- a/artshow/static/artshow/bid_entry.js
+++ b/artshow/static/artshow/bid_entry.js
@@ -28,11 +28,24 @@ document.addEventListener('DOMContentLoaded', () => {
   pieceIdField.addEventListener('input', clearFields);
   locationSelect.addEventListener('input', setNotSaved);
   buyNowCheckbox.addEventListener('input', setNotSaved);
+  buyNowCheckbox.addEventListener('input', toggleDisableOnNonBuyNowElements);
   for (var i = 0; i < bidderFields.length; ++i) {
     bidderFields[i].addEventListener('input', setNotSaved);
     bidFields[i].addEventListener('input', setNotSaved);
   }
 });
+
+function toggleDisableOnNonBuyNowElements() {
+  const maybeDisabled = !!buyNowCheckbox.checked;
+  const nFields = bidderFields.length;
+  for (var i = 1; i < nFields; i++) {
+    /* for every bidder but the first bidder */
+    bidderFields[i].disabled = maybeDisabled;
+    bidFields[i].disabled = maybeDisabled;
+  }
+  /* we still need the first bidder's bidder ID */
+  bidFields[0].disabled = maybeDisabled;
+}
 
 function updateBids(json, newStatus) {
   if ('error' in json) {

--- a/artshow/static/artshow/bid_sheets.css
+++ b/artshow/static/artshow/bid_sheets.css
@@ -36,6 +36,7 @@ body {
   height: 1in;
   display: grid;
   grid-template-rows: repeat(4, 1fr);
+  text-align: center;
 }
 
 .bid-info div {

--- a/artshow/static/artshow/bid_sheets.css
+++ b/artshow/static/artshow/bid_sheets.css
@@ -36,7 +36,6 @@ body {
   height: 1in;
   display: grid;
   grid-template-rows: repeat(4, 1fr);
-  text-align: center;
 }
 
 .bid-info div {
@@ -93,6 +92,7 @@ body {
 
 .bid-sticker span {
   display: table-cell;
+  padding: 5px;
   vertical-align: middle;
 }
 

--- a/artshow/templates/artshow/bid_sheets.html
+++ b/artshow/templates/artshow/bid_sheets.html
@@ -14,7 +14,7 @@
       <div class="label">Minimum Bid</div>
       <div>${{ piece.min_bid }}</div>
       <div class="label">Auto Buy</div>
-      <div>{% if piece.buy_now %}${{ piece.buy_now }}{% else %}N/A{% endif %}</div>
+      <div>{% if piece.buy_now %}1st bid only; please see below{% else %}N/A{% endif %}</div>
       {% endif %}
     </div>
     <div class="piece-id">{{ piece.code }}</div>
@@ -36,7 +36,7 @@
     </div>
     {% else %}
     <div class="bid-stickers">
-      <div class="bid-sticker"><span>Place 1st bid{% if piece.buy_now %} or auto-buy{% endif %} here.</span></div>
+      <div class="bid-sticker"><span>Place 1st bid{% if piece.buy_now %} or auto buy of ${{ piece.buy_now }}{% endif %} here.</span></div>
       <div class="bid-sticker"><span>Place 2nd bid here.</span></div>
       <div class="bid-sticker"><span>Place 3rd bid here.</span></div>
       <div class="bid-sticker"><span>Place 4th bid here.</span></div>

--- a/artshow/templates/artshow/bid_sheets.html
+++ b/artshow/templates/artshow/bid_sheets.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load humanize %}
 <html>
 <head>
 <title>Art Show Bid Sheets {% if artist %}({{ artist.name }}){% endif %}</title>
@@ -12,9 +13,9 @@
     <div class="bid-info">
       {% if not piece.not_for_sale %}
       <div class="label">Minimum Bid</div>
-      <div>${{ piece.min_bid }}</div>
+      <div>${{ piece.min_bid|intcomma }}</div>
       <div class="label">Auto Buy</div>
-      <div>{% if piece.buy_now %}1st bid only; please see below{% else %}N/A{% endif %}</div>
+      <div>{% if piece.buy_now %}1st bid only{% else %}N/A{% endif %}</div>
       {% endif %}
     </div>
     <div class="piece-id">{{ piece.code }}</div>
@@ -36,7 +37,7 @@
     </div>
     {% else %}
     <div class="bid-stickers">
-      <div class="bid-sticker"><span>Place 1st bid{% if piece.buy_now %} or auto buy of ${{ piece.buy_now }}{% endif %} here.</span></div>
+      <div class="bid-sticker"><span>Place 1st bid here{% if piece.buy_now %}, or auto buy for ${{ piece.buy_now|intcomma }}{% endif %}.</span></div>
       <div class="bid-sticker"><span>Place 2nd bid here.</span></div>
       <div class="bid-sticker"><span>Place 3rd bid here.</span></div>
       <div class="bid-sticker"><span>Place 4th bid here.</span></div>

--- a/artshow/tests/test_bid_entry.py
+++ b/artshow/tests/test_bid_entry.py
@@ -86,6 +86,7 @@ class BidEntryTests(TestCase):
         response = self.client.get('/artshow/entry/bids/1/1/')
         self.assertEqual(response.json(), {
             'bids': [],
+            'buy_now': 50,
             'last_updated': None,
             'location': '',
             'locations': ['A1', 'A2'],
@@ -102,6 +103,7 @@ class BidEntryTests(TestCase):
                  'bid': 20,
                  'buy_now_bid': False},
             ],
+            'buy_now': 50,
             'last_updated': None,
             'location': 'A1',
             'locations': ['A1', 'A2'],
@@ -247,6 +249,7 @@ class BidEntryTests(TestCase):
                  'bid': 20,
                  'buy_now_bid': False},
             ],
+            'buy_now': 50,
             'last_updated': None,
             'location': 'A1',
             'locations': ['A1', 'A2'],

--- a/artshowjockey/settings.py
+++ b/artshowjockey/settings.py
@@ -163,6 +163,7 @@ INSTALLED_APPS = [
     'tinyreg',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.humanize',
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.messages',


### PR DESCRIPTION
This aims to move around some of the auto buy wording on the bid sheets such that placement of the first bid visibly removes the option from subsequent bidders per the business rules of the auction.

We also include here some augmentations to the mobile bid entry form that disable all fields but the one for inputting the bidder ID of the bidder who "bought it now."