### PR TITLE
Handle OAuth errors better

### DIFF
--- a/tinyreg/tests/test_oauth.py
+++ b/tinyreg/tests/test_oauth.py
@@ -2,7 +2,7 @@ import requests
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.test import LiveServerTestCase
+from django.test import LiveServerTestCase, override_settings
 from django.urls import reverse
 
 from peeps.models import Person
@@ -17,6 +17,7 @@ from .views import CurrentUserView
 # log.setLevel(logging.DEBUG)
 
 
+@override_settings(DEBUG=True)
 class OAuthTests(LiveServerTestCase):
     def setUp(self):
         settings.SITE_ROOT_URL = self.live_server_url
@@ -225,6 +226,57 @@ class OAuthTests(LiveServerTestCase):
         url = reverse('oauth-redirect')
         response = requests.get(self.live_server_url + url)
         self.assertEqual(response.status_code, 200)
+
+        user = User.objects.get(username="42")
+        person = user.person
+        self.assertEqual(person.reg_id, "42")
+        self.assertEqual(person.name, 'Foxy McFoxerson')
+        self.assertEqual(person.preferred_name, 'Mr. Fox')
+        self.assertEqual(person.address1, '123 Main St.')
+        self.assertEqual(person.address2, 'Apt 3')
+        self.assertEqual(person.city, 'New York')
+        self.assertEqual(person.state, 'NY')
+        self.assertEqual(person.postcode, '12345')
+        self.assertEqual(person.country, 'US')
+        self.assertEqual(person.phone, '800-555-1234')
+        self.assertEqual(person.email, 'fox@example.com')
+
+    def test_concurrent_logins(self):
+        CurrentUserView.current_user = {
+            'id': 42,
+            'firstName': 'Foxy',
+            'lastName': 'McFoxerson',
+            'preferredName': 'Mr. Fox',
+            'addressLine1': '123 Main St.',
+            'addressLine2': 'Apt 3',
+            'addressCity': 'New York',
+            'addressState': 'NY',
+            'addressZipcode': '12345',
+            'addressCountry': 'US',
+            'phone': '800-555-1234',
+            'email': 'fox@example.com',
+        }
+
+        redirect_url = reverse('oauth-redirect')
+
+        with requests.Session() as s:
+            first_redirect = s.get(self.live_server_url + redirect_url,
+                                   allow_redirects=False)
+            self.assertEqual(first_redirect.status_code, 302)
+
+            second_redirect = s.get(self.live_server_url + redirect_url,
+                                    allow_redirects=False)
+            self.assertEqual(second_redirect.status_code, 302)
+
+            first_completion = s.get(first_redirect.headers['Location'])
+            self.assertEqual(first_completion.status_code, 200)
+            self.assertEqual(first_completion.history[-1].headers['Location'],
+                             reverse('artshow-manage'))
+
+            second_completion = s.get(second_redirect.headers['Location'])
+            self.assertEqual(second_completion.status_code, 200)
+            self.assertEqual(second_completion.history[-1].headers['Location'],
+                             reverse('artshow-manage'))
 
         user = User.objects.get(username="42")
         person = user.person


### PR DESCRIPTION
Reuse the OAuth session state between requests so that concurrent requests work and ignore missing session state if the user is already logged in.