### PR TITLE
Handle ConCat setting optional fields to null

### DIFF
--- a/tinyreg/tests/test_oauth.py
+++ b/tinyreg/tests/test_oauth.py
@@ -90,6 +90,39 @@ class OAuthTests(LiveServerTestCase):
         self.assertEqual(person.phone, '')
         self.assertEqual(person.email, 'fox@example.com')
 
+    def test_create_user_optional_fields_null(self):
+        CurrentUserView.current_user = {
+            'id': 42,
+            'firstName': 'Foxy',
+            'lastName': 'McFoxerson',
+            'addressLine1': '123 Main St.',
+            'addressLine2': None,
+            'addressCity': 'New York',
+            'addressState': 'NY',
+            'addressZipcode': '12345',
+            'addressCountry': 'US',
+            'phone': None,
+            'email': 'fox@example.com',
+        }
+
+        url = reverse('oauth-redirect')
+        response = requests.get(self.live_server_url + url)
+        self.assertEqual(response.status_code, 200)
+
+        user = User.objects.get(username="42")
+        person = user.person
+        self.assertEqual(person.reg_id, "42")
+        self.assertEqual(person.name, 'Foxy McFoxerson')
+        self.assertEqual(person.preferred_name, '')
+        self.assertEqual(person.address1, '123 Main St.')
+        self.assertEqual(person.address2, '')
+        self.assertEqual(person.city, 'New York')
+        self.assertEqual(person.state, 'NY')
+        self.assertEqual(person.postcode, '12345')
+        self.assertEqual(person.country, 'US')
+        self.assertEqual(person.phone, '')
+        self.assertEqual(person.email, 'fox@example.com')
+
     def test_log_in_with_existing_person(self):
         CurrentUserView.current_user = {
             'id': 42,

--- a/tinyreg/views.py
+++ b/tinyreg/views.py
@@ -85,15 +85,15 @@ def oauth_complete(request):
         person = Person(
             name=user_info['firstName'] + ' ' + user_info['lastName'],
             address1=user_info['addressLine1'],
-            address2=user_info.get('addressLine2', ''),
+            address2=user_info.get('addressLine2') or '',
             city=user_info['addressCity'],
             state=user_info['addressState'],
             postcode=user_info['addressZipcode'],
             country=user_info['addressCountry'],
-            phone=user_info.get('phone', ''),
+            phone=user_info.get('phone') or '',
             email=user_info['email'],
             reg_id=reg_id,
-            preferred_name=user_info.get('preferredName', ''),
+            preferred_name=user_info.get('preferredName') or '',
             user=user)
         person.save()
 


### PR DESCRIPTION
Previously they were missing. They can be explicitly null too. Apparently.